### PR TITLE
Fixed unreachable code and added missing includes (for std::function and std::shared_ptr).

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -15,7 +15,7 @@ using std::vector;
 
 using namespace Couchbase;
 
-int main(int argc, char **argv)
+int main(int argc, const char **argv)
 {
     //! Connect to the client
     string connstr(argc > 1 ? argv[1] : "couchbase://localhost/default");

--- a/include/libcouchbase/couchbase++.h
+++ b/include/libcouchbase/couchbase++.h
@@ -12,6 +12,8 @@
 #include <vector>
 #include <list>
 #include <iostream>
+#include <functional>
+#include <memory>
 #include <libcouchbase/couchbase++/forward.h>
 
 namespace Couchbase {

--- a/include/libcouchbase/couchbase++/operations.inl.h
+++ b/include/libcouchbase/couchbase++/operations.inl.h
@@ -32,9 +32,6 @@ template <typename C, typename R> inline R
 Operation<C,R>::run(Client& client) {
     BatchContext b(client);
     Status st = schedule(b);
-    if (!st) {
-        return R::setcode(res, st);
-    }
     if (st) {
         b.submit();
         client.wait();


### PR DESCRIPTION
This was not compiling under Archlinux as functional and memory are not included by default.
Furthermore, there was some unreachable code in operations.inl.h file.