### PR TITLE
One occurence of ERROR not changed to State::STATE_ERROR

### DIFF
--- a/include/libcouchbase/couchbase++/client.inl.h
+++ b/include/libcouchbase/couchbase++/client.inl.h
@@ -392,7 +392,7 @@ template <typename T> void
 DurableResponse<T>::dur_bail(Status& st)
 {
     EndureResponse::setcode(m_dur, st);
-    m_state = ERROR;
+    m_state = State::STATE_ERROR;
 }
 
 } // namespace Couchbase


### PR DESCRIPTION
The current example.cpp doesn't compile because of ERROR not being defined