### PR TITLE
Fix Valgrind complaint of mismatched delete for QueryRow m_buf

### DIFF
--- a/include/libcouchbase/couchbase++/query.inl.h
+++ b/include/libcouchbase/couchbase++/query.inl.h
@@ -65,7 +65,7 @@ void
 QueryRow::detatch() {
     if (m_buf == NULL && !m_row.empty()) {
         char *tmp = new char[m_row.size()];
-        m_buf.reset(tmp);
+        m_buf.reset(tmp, std::default_delete<char[]>());
         memcpy(tmp, m_row.data(), m_row.size());
         m_row = Buffer(tmp, m_row.size());
     }


### PR DESCRIPTION
Default deleter for std::shared_ptr is delete but usage requires delete[].  Fix is to supply the correct deleter when new value is assigned.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>