### PR TITLE
fix: usage of query.h from multiple compilation units

### DIFF
--- a/include/libcouchbase/couchbase++/query.h
+++ b/include/libcouchbase/couchbase++/query.h
@@ -1,4 +1,13 @@
+#ifndef LCB_PLUSPLUS_H
+#error "Include <libcouchbase/couchbase++.h> first!"
+#endif
+
+#ifndef LCB_PLUSPLUS_QUERY_H
+#define LCB_PLUSPLUS_QUERY_H
+
 #include <libcouchbase/n1ql.h>
+#include "row_common.h"
+
 namespace Couchbase {
 namespace Internal {
 extern "C" { static void n1qlcb(lcb_t,int,const lcb_RESPN1QL*); }
@@ -74,7 +83,7 @@ public:
 private:
     friend class CallbackQuery;
     friend class Query;
-    QueryRow(const lcb_RESPN1QL *);
+    inline QueryRow(const lcb_RESPN1QL *);
     Buffer m_row;
     std::shared_ptr<char> m_buf;
 };
@@ -208,3 +217,5 @@ private:
 }
 
 #include <libcouchbase/couchbase++/query.inl.h>
+
+#endif


### PR DESCRIPTION
Fixes:
- There is a missing include guard in the `query.h`, it should be the same as in the `views.h`
- `row_common.h` should be included, otherwise you get a compilation error
- `QueryRow::QueryRow` should be marked as `inline`

These changes fix compile-time/linker error when you include `query.h` from multiple compilation units.